### PR TITLE
Upgrade to Sentry 1.5.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
   ],
   "require" : {
     "silverstripe/framework": "~3.1",
-    "sentry/sentry": "0.22.0"
+    "sentry/sentry": "1.5.0"
   },
   "extra" : {
     "installer-name": "sentrylogger"


### PR DESCRIPTION
Hi there,

Thanks for this great extension. We've been using it lately and I have noticed that Sentry was using the old SDK. I was wondering if it would be possible to upgrade to the latest version. I have tested it with a SS instance version 3.2 and it works.

Cheers,
G.